### PR TITLE
Added support for the Secp256k1 curve for Tezos (XTZ) tz2 addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,10 +481,9 @@ Compatibility has been checked:
 
 # XTZ (Tezos)
 
-XTZ is using the same derivation standard and same curve as XLM, so
-please read the caveats there.
+XTZ is using three different curves. This tool currently supports two of the curves, ED25519 and Secp256k1, for tz1 and tz2 addresses, respectively. Please see the caveats concerning ED25519 mentioned in the section on XLM.
 
-Private keys for Tezos without and with passphrase:
+Private keys for Tezos without and with passphrase (ED25519/tz1):
 
 ```
 $ ./bip39.py <<< "nation grab van ride cloth wash endless gorilla speed core dry shop raise later wedding sweet minimum rifle market inside have ill true analyst" | ./seed2xprv-ed25519.py | ./xderive.py 44h 1729h 0h 0h | ./x2xtz.py
@@ -502,9 +501,28 @@ $ echo -e "nation grab van ride cloth wash endless gorilla speed core dry shop r
 tz1aKHaJqpYqks5ttzdxqREAq2TuaV8w9Axh
 ```
 
+Private keys for Tezos without and with passphrase (Secp256k1/tz2):
+
+```
+$ ./bip39.py <<< "nation grab van ride cloth wash endless gorilla speed core dry shop raise later wedding sweet minimum rifle market inside have ill true analyst" | ./seed2xprv.py | ./xderive.py 44h 1729h 0h 0h | ./x2xtz.py
+spsk24mup6mo8132KGD2goYpV17FEvvDnk1RQYD5EcTCpARaVcTC7p
+$ echo -e "nation grab van ride cloth wash endless gorilla speed core dry shop raise later wedding sweet minimum rifle market inside have ill true analyst\ndo not show my wife" | ./bip39.py | ./seed2xprv.py | ./xderive.py 44h 1729h 0h 0h | ./x2xtz.py
+spsk2xoFEe5VrmPYyQuYQUaD27zXH5e7vE9hTVgtDdRrV9fdCk3dFh
+```
+
+Addresses for these:
+
+```
+$ ./bip39.py <<< "nation grab van ride cloth wash endless gorilla speed core dry shop raise later wedding sweet minimum rifle market inside have ill true analyst" | ./seed2xprv.py | ./xderive.py 44h 1729h 0h 0h n | ./x2xtz.py
+tz2RvYDs1YgBfUXGPo9UijX4Ck2HcbQ7C63p
+$ echo -e "nation grab van ride cloth wash endless gorilla speed core dry shop raise later wedding sweet minimum rifle market inside have ill true analyst\ndo not show my wife" | ./bip39.py | ./seed2xprv.py | ./xderive.py 44h 1729h 0h 0h n | ./x2xtz.py
+tz2N7Tvk39ckAwDPn8MnSQ5Q25yAckm4TNGM
+```
+
 Compatibility has been checked:
   - Trezor one HAS NO SUPPORT for XTZ on 2021-03-01,
   - Ledger Nano S 2021-03-01,
+  - Ledger Nano X 2021-05-16,
   - wallet.tezbox.com 2021-03-01.
 
 # Generating the last word in the passphrase.

--- a/lib/mbp32.py
+++ b/lib/mbp32.py
@@ -318,12 +318,19 @@ class XKey(NamedTuple):
 
     def to_xtz(self) -> str:
         if isinstance(self.key, (ED25519Priv, ED25519Pub)):
+            # ED25519 tz1 addresses
             if self.version == Version.PRIVATE:
-                return TezosKey.from_secret_exponent(self.key.get_private_bytes()).secret_key()
+                return TezosKey.from_secret_exponent(self.key.get_private_bytes(), curve = b'ed').secret_key()
             else:
-                return TezosKey.from_public_point(self.key.get_public_bytes()).public_key_hash()
+                return TezosKey.from_public_point(self.key.get_public_bytes(), curve = b'ed').public_key_hash()
+        elif isinstance(self.key, (Secp256k1Priv, Secp256k1Pub)):
+            # Secp256k1 tz2 addresses
+            if self.version == Version.PRIVATE:
+                return TezosKey.from_secret_exponent(self.key.get_private_bytes(), curve = b'sp').secret_key()
+            else:
+                return TezosKey.from_public_point(self.key.get_public_bytes(), curve = b'sp').public_key_hash()
         else:
-            raise ValueError("Can only derive XTZ from ED25519")
+            raise ValueError("Can only derive XTZ from ED25519 or Secp256k1")
 
 
 if __name__ == "__main__":

--- a/tests/0011-xtz.sh
+++ b/tests/0011-xtz.sh
@@ -4,10 +4,20 @@ set -e
 set -o pipefail
 set -u
 
+# ED25519 curve for tz1 addresses
 diff -u <(./x2xtz.py <<< xprvA1TDzWUPxfe6jpSkMidYsEPPkG9B5FqUYBKt3xYmMNSvNmVtPVpbPCdQP5faUQddr1L7VfGav574YCPW4N3ksCrYjd38m24aWVJw8KR7VXs) - <<EOF
 edsk3SASh4w2ZVAMGYuPvG617nxabj5Y97rBn18Jg2ZiLReMvrMfvD
 EOF
 
 diff -u <(./x2xtz.py <<< xpub6ESaQ21Ho3CPwSWxGS676y7EyQfvYtqLu7tFYvwSnUktcxrHEbT3un9EiPHyAJNEDU9gerqKWhVJCMJ5jr8LfZUns3hVyrYnXurXgMkfB9u) - <<EOF
 tz1hDY7HSpaCFNeffwbF2mjmegdHAQUgyxg9
+EOF
+
+# Secp256k1 curve for tz2 addresses
+diff -u <(./x2xtz.py <<< xprv9zyre4rnL24WXvVS1nuBAZLzrzTb4Mz7pjUegPoD6Hm9zjRQrh31PY6Qo6xSaEjsjEDyfAy4RCjGwmt7mYMz2pKjbJhuGsHEdEaGrQLwLGZ) - <<EOF
+spsk24mup6mo8132KGD2goYpV17FEvvDnk1RQYD5EcTCpARaVcTC7p
+EOF
+
+diff -u <(./x2xtz.py <<< xpub6DyD3aPgAPcokQZu7pSBXhHjR2J5TphyBxQFUnCpedJ8sXkZQEMFwLQteNPjS44pSih4RWCooKi7zc2Pa81Y2oYdFYEKsRAqHbibv8CxnFH) - <<EOF
+tz2RvYDs1YgBfUXGPo9UijX4Ck2HcbQ7C63p
 EOF


### PR DESCRIPTION
Tezos supports three curves - ED25519, Secp256k1, and Secp256r1 (for Tezos tz1, tz2, and tz3 addresses, respectively). This pull requests adds support for the Secp256k1 curve (tz2 addresses).

Tests in tests/0011-xtz.sh were updated. All tests are passing (except for a few of the byexample tests that were not passing before this update).

Also tested and verified against an actual Ledger Nano X device.

README was updated accordingly.